### PR TITLE
Issue 37: Heatmap errors when a group has no replicates

### DIFF
--- a/bin/metadata_pairwise.r
+++ b/bin/metadata_pairwise.r
@@ -32,8 +32,9 @@ rownames(metadata) <- metadata$sample
 #Create grouplist and remove replicates from the list
 no.replicates <- table(metadata$group)
 groups <- names(no.replicates)[no.replicates > 1]
-#If more than three samples and more than one group, continue with group analysis
-if (length(groups) >= 1 )
+groupcount <- names(no.replicates)
+#If there is at least one group with replicates and two groups in total, and more than 3 samples, continue with group analysis
+if (length(groups) >= 1 && length(groupcount)>=2 && length(metadata$sampleid) > 3 )
 {
     write.table(metadata, file="filtered_metadata.tsv", sep="\t", row.names=FALSE, quote=FALSE)
 }

--- a/modules/nf-core/qiime/betadiversity/main.nf
+++ b/modules/nf-core/qiime/betadiversity/main.nf
@@ -17,7 +17,7 @@ process QIIME_BETADIVERSITY {
     path "versions.yml", emit: versions
 
     script:
-    """
+    """ 
     qiime diversity beta-group-significance \
         --i-distance-matrix ${distance} \
         --m-metadata-file ${metadata} \


### PR DESCRIPTION
QIIME_METADATAFILTER is now subject to the following filtering before producing a metadata tsv, which is required by steps QIIME_DIVERSITYCORE and QIIME_HEATMAP:

Of samples remaining after filtering for low quality reads:
1) There must be at least 1 replicate in 1 group
2) There must be at least 2 groups
3) There must be more than 3 samples