### PR TITLE
sourmash use assembly IDs as keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # aladdin-shotgun: Changelog
 
+## v0.0.5
+
+### `Changed`
+- Sourmash output now uses sequence IDs (assembly accession numbers) as keys. Pipeline now generates a Qiime2 feature table with these keys, in addition to the table with collapsed taxonomy.
+
 ## v0.0.4 
 
 ### `Added`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ nextflow run Zymo-Research/aladdin-shotgun \
     --awsqueue "<SQS ARN>" \
     --outdir "<output dir on S3>" \
     -r "0.0.4"
-    --name "<analysis name>"
 ```
 1. The parameter `--design` is required. It must be a CSV file with the following format.
 ```
@@ -70,7 +69,6 @@ sample3,s3_run1_R1.fastq.gz,s3_run1_R2.fastq.gz,groupB,,
 2. The parameter `--database` is used to change taxonomy profiler and database. It has a default value 'sourmash-zymo'. You can skip this if you don't want to change it.
 3. The parameters `--awsregion`, `--awsqueue`, `-work-dir`, and `--outdir` are required when running on AWS Batch, the latter two must be directories on S3.
 4. The parameter `-r` will run a specific release of the pipeline. If not specified, it will run the the `main` branch instead.
-5. The parameter `--name` will add a title to the report. This is optional.
 
 There are many other options built in the pipeline to customize your run and handle specific situations, please refer to the [Usage Documentation](docs/usage.md).
 
@@ -79,8 +77,7 @@ There are many other options built in the pipeline to customize your run and han
 nextflow run Zymo-Research/aladdin-shotgun \
     -profile docker \
     --design "<path to design CSV file>" \
-    --database sourmash-zymo \
-    --name "<analysis name>"
+    --database sourmash-zymo
 ```
 Please see above for requirements of the design CSV file.
 

--- a/modules/nf-core/qiime/datamerge/main.nf
+++ b/modules/nf-core/qiime/datamerge/main.nf
@@ -22,6 +22,7 @@ process QIIME_DATAMERGE {
     path('merged_filtered_counts_collapsed.tsv') , emit: filtered_counts_collapsed_tsv
     path('versions.yml')                         , emit: versions
     path('*.qza')
+    path('merged_filtered_counts.tsv')
 
     script:
     """
@@ -39,6 +40,11 @@ process QIIME_DATAMERGE {
         --p-min-frequency ${params.min_frequency} \
         --p-min-samples ${params.min_samples} \
         --o-filtered-table merged_filtered_counts.qza
+    
+    qiime tools export \
+        --input-path merged_filtered_counts.qza \
+        --output-path merged_filtered_counts_out
+    biom convert -i merged_filtered_counts_out/feature-table.biom -o merged_filtered_counts.tsv --to-tsv
 
     qiime_taxmerge.py $taxonomy
     qiime tools import \


### PR DESCRIPTION
Sourmash output now uses sequence IDs (assembly accession numbers) as keys. Pipeline now generates a Qiime2 feature table with these keys, in addition to the table with collapsed taxonomy.