### PR TITLE
Temporary Bug Fix: AMR++ TypeError "string indices must be integer"

### DIFF
--- a/bin/SNP_Verification_Processes/nTupleCheck.py
+++ b/bin/SNP_Verification_Processes/nTupleCheck.py
@@ -167,7 +167,7 @@ def nTupleCheck(read, gene, mapOfInterest, seqOfInterest, config):
                     for mt in mtInfo[2]: 
                         currentResBool = False
                         for queryIndex in tuple(mapOfInterest[mtInfo[1]-1]):
-                            if queryIndex == '-': continue
+                            if queryIndex == '-' or queryIndex == None: continue
                             if mt == seqOfInterest[queryIndex]:
                                 currentResBool = True
                                 if config.getboolean('SETTINGS', 'MT_AND_WT'):

--- a/modules/local/resistome/resistome_run.nf
+++ b/modules/local/resistome/resistome_run.nf
@@ -1,6 +1,6 @@
 process RESISTOME_RUN {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_high'
 
     input:
     tuple val(meta), path(bam)

--- a/modules/local/resistome/resistome_snpverify.nf
+++ b/modules/local/resistome/resistome_snpverify.nf
@@ -1,6 +1,6 @@
 process RESISTOME_SNPVERIFY {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_high'
 
     input:
     tuple val(meta), path(bam)


### PR DESCRIPTION
- memory for RESISTOME_SNPVERIFY and RESISTOME_RUN increased to process_high
- SNP_Verification.py code changed so sequences that cause the TypeError are skipped