### PR TITLE
0.0.11

### DIFF
--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -2,10 +2,10 @@ process FASTP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::fastp=0.23.2"
+    conda "bioconda::fastp=0.23.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastp:0.23.2--h79da9fb_0' :
-        'quay.io/biocontainers/fastp:0.23.2--h79da9fb_0' }"
+        'https://depot.galaxyproject.org/singularity/fastp:0.23.4--hadf994f_3' :
+        'quay.io/biocontainers/fastp:0.23.4--hadf994f_3' }"
 
     input:
     tuple val(meta), path(reads)
@@ -92,7 +92,6 @@ process FASTP {
             $min_length \\
             $merge_fastq \\
             --thread $task.cpus \\
-            --detect_adapter_for_pe \\
             $args \\
             2> ${prefix}.fastp.log
 

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -37,7 +37,8 @@ process FASTQC {
         [ -f ${prefix}_R1.fastq.gz ] || ln -s ${reads[0]} ${prefix}_R1.fastq.gz
         [ -f ${prefix}_R2.fastq.gz ] || ln -s ${reads[1]} ${prefix}_R2.fastq.gz
 
-        fastqc $args --threads $task.cpus ${prefix}_R1.fastq.gz ${prefix}_R2.fastq.gz
+        fastqc $args --threads $task.cpus ${prefix}_R1.fastq.gz
+        fastqc $args --threads $task.cpus ${prefix}_R2.fastq.gz
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -203,7 +203,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
         singularity.enabled    = false
         podman.enabled         = false
         shifter.enabled        = false

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -391,7 +391,7 @@ workflow PROFILING {
         .map { it[0] }
         .collect()
         .map {
-            "The following samples failed taxonomy profiling steps:\n${it.join("; ")}\nA common cause for this is lack of significant match against the database."
+            "The following samples failed taxonomy profiling steps:\n${it.join("; ")}\nPlease contact us if you want to troubleshoot them."
         }
         .set {ch_warning_message }
     ch_warning_message


### PR DESCRIPTION
* Fix #106
* Fix #107 
* Update the warning message for samples that failed profiling. Profiling with sourmash can sometimes run out of memory. Changed this warning message for a temporary fix. Will look into multi-thread sourmash and increase compute resource as permanent fix.