### PR TITLE
Sourmash database and default kmer update

### DIFF
--- a/conf/databases.config
+++ b/conf/databases.config
@@ -2,7 +2,13 @@
 
 params {
     databases {
-        'sourmash-zymo' {
+        'sourmash-zymo-2024' {
+            tool = 'sourmash'
+            db_params = ''
+            db_path = "s3://aladdin-genomes/shotgun_reference/sourmash-zymo-2024/**{.csv,k${params.sourmash_kmersize}.zip}"
+            host_lineage = 's3://aladdin-genomes/shotgun_reference/sourmash-zymo-2024/lineage/host_genomes_tax.csv'
+        }
+        'sourmash-zymo-2023' {
             tool = 'sourmash'
             db_params = ''
             db_path = "s3://aladdin-genomes/shotgun_reference/sourmash-zymo/**{.csv,k${params.sourmash_kmersize}.zip}"
@@ -13,11 +19,17 @@ params {
             db_params = ''
             db_path = 's3://aladdin-genomes/shotgun_reference/metaphlan4/'
         }
-        'sourmash-zymo-dev' {
+        'sourmash-zymo-dev-2024' {
             tool = 'sourmash'
             db_params = ''
-            db_path = "s3://zymo-igenomes/zymo/zymobiomics_shotgun_ref/sourmash/**{.csv,k${params.sourmash_kmersize}.zip}"
-            host_lineage = 's3://zymo-igenomes/zymo/zymobiomics_shotgun_ref/sourmash/lineage/host_genomes_tax.csv'
+            db_path = "s3://zymo-igenomes/zymo/zymobiomics_shotgun_ref/sourmash/June2024/**{.csv,k${params.sourmash_kmersize}.zip}"
+            host_lineage = 's3://zymo-igenomes/zymo/zymobiomics_shotgun_ref/sourmash/June2024/lineage/host_genomes_tax.csv'
+        }
+        'sourmash-zymo-dev-2023' {
+            tool = 'sourmash'
+            db_params = ''
+            db_path = "s3://zymo-igenomes/zymo/zymobiomics_shotgun_ref/sourmash/July2023/**{.csv,k${params.sourmash_kmersize}.zip}"
+            host_lineage = 's3://zymo-igenomes/zymo/zymobiomics_shotgun_ref/sourmash/July2023/lineage/host_genomes_tax.csv'
         }
         'metaphlan4-db-dev' {
             tool = 'metaphlan4'

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
 
     // Input options
     design                     = null
-    database                   = 'sourmash-zymo'
+    database                   = 'sourmash-zymo-2024'
 
     // References
     genome                     = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -111,7 +111,7 @@ params {
     centrifuge_save_reads      = false // added directly to module in profiling.nf
 
     // sourmash
-    sourmash_kmersize          = 51
+    sourmash_kmersize          = 31
     sourmash_threshold_bp      = 5000
     sourmash_strict_filtering  = false
     sourmash_trim_low_abund    = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -25,8 +25,8 @@
                 "database": {
                     "type": "string",
                     "description": "Select the reference database and the tool you would like to use for taxonomic profiling. Your choice will dictate the ranking and nomenclature of the taxonomy profile. We provide several popular reference databases to choose from, but recommend the sourmash-compatible database from Zymo Research.",
-                    "enum": ["sourmash-zymo", "metaphlan4-db"],
-                    "default": "sourmash-zymo"
+                    "enum": ["sourmash-zymo-2024", "metaphlan4-db", "sourmash-zymo-2023"],
+                    "default": "sourmash-zymo-2024"
                 },
                 "outdir": {
                     "type": "string",
@@ -452,14 +452,14 @@
                 },
                 "sourmash_kmersize": {
                     "type": "integer",
-                    "default": 51,
+                    "default": 31,
                     "enum": [51,31,21],
-                    "description": "Sourmash breaks reads down into k-mers which are compared against database for taxonomic assignment. A length of 51 is very robust and allows for good taxonomic resolution down to species level while keeping false positives to a minimum, but is very stringent. Smaller k-mer sizes like 31 can be more sensitive at the genus level but may allow for more false positive calls. We recommend 51 for most projects, however if your samples likely contain poorly annotated genomes, smaller k-mers may provide more useful results.",
+                    "description": "Sourmash breaks reads down into k-mers which are compared against database for taxonomic assignment. Sourmash recommends k=31 for most cases. k=51 increase specificity at the expense of sensitivity, therefore should be used when most species in your samples have very closely related genomes in the database. k=21 is useful when species in your sample have no good reference genomes and you just want classification on the family level or above.",
 		            "advanced": true
                 },
                 "sourmash_threshold_bp": {
                     "type": "integer",
-                    "description": "Sourmash will only report a match to a genome in the database when the estimated overlap between sample and the reference is at least this many base pairs. Choose a smaller number to increase sensitivity to low abundant species. Default is 50,000bp.",
+                    "description": "Sourmash will only report a match to a genome in the database when the estimated overlap between sample and the reference is at least this many base pairs. Choose a smaller number to increase sensitivity to low abundant species or small genomes like virus. Default is 5,000bp.",
                     "default": 5000,
                     "minimum": 1000,
                     "maximum": 1000000,


### PR DESCRIPTION
add new version of the sourmash database and the default kmer size to 31. The main difference between the old and new database is that the new one uses a newer version of the GTDB database (214) and at the "representative genomes" level instead of at the "all genomes" level to increase performance. Because of this, changing kmer size to 31 would hopefully maintain the sensitivity.