### PR TITLE
Missing Taxonomy Files Error Fix

### DIFF
--- a/modules/local/qiime2_ancombc_initial.nf
+++ b/modules/local/qiime2_ancombc_initial.nf
@@ -10,7 +10,7 @@ process QIIME2_ANCOMBC_INITIAL {
 
     output:
     tuple path("*ancombc.qza"), val(taxlevel)  , emit: ancom, optional: true
-    path("*ancombc.qza")
+    path("*ancombc.qza")                       , optional: true
     tuple env(failfilter), val(taxlevel)       , emit: failcheck
     path "versions.yml"                        , emit: versions
 
@@ -27,6 +27,8 @@ process QIIME2_ANCOMBC_INITIAL {
     biom convert -i exported/feature-table.biom -o ${table.baseName}-level-${taxlevel}.feature-table.tsv --to-tsv
 
     if [ \$(grep -v '^#' -c ${table.baseName}-level-${taxlevel}.feature-table.tsv) -lt 3 ]; then
+        failfilter="true"
+    elif [ ${taxlevel} == 1 ]; then
         failfilter="true"
     else
         qiime composition ancombc \

--- a/modules/local/qiime2_export_absolute.nf
+++ b/modules/local/qiime2_export_absolute.nf
@@ -13,7 +13,7 @@ process QIIME2_EXPORT_ABSOLUTE {
     output:
     path("feature-table.tsv")        , emit: tsv
     path("feature-table.biom")       , emit: biom
-    path("table-[2-7].qza")          , emit: collapse_qza
+    path("table-[${tax_agglom_min}-${tax_agglom_max}].qza")          , emit: collapse_qza
     path("abs-abund-table-*.tsv")    , emit: abundtable
     path "versions.yml"              , emit: versions
 

--- a/modules/nf-core/qiime/barplot/main.nf
+++ b/modules/nf-core/qiime/barplot/main.nf
@@ -24,7 +24,7 @@ process QIIME_BARPLOT {
     qiime taxa barplot --i-table $counts --i-taxonomy $taxonomy --m-metadata-file $metadata --o-visualization allsamples_compbarplot.qzv
     qiime tools export --input-path allsamples_compbarplot.qzv --output-path allsamples_exported_QIIME_barplot
     
-    array=( \$( seq 1 $taxa_max ) )
+    array=( \$( seq 1 ${taxa_max} ) )
 
     for i in \${array[@]}
     do

--- a/subworkflows/local/diversity.nf
+++ b/subworkflows/local/diversity.nf
@@ -12,6 +12,7 @@ include { QIIME2_ANCOMBC                               } from '../../subworkflow
 include { QIIME_IMPORT                                  } from '../../modules/nf-core/qiime/import/main'
 include { QIIME2_FILTERSAMPLES                          } from '../../modules/local/qiime2_filtersamples'
 include { QIIME2_PREPTAX                                } from '../../modules/local/qiime2_preptax'
+include { FIND_MAX_AVAILABLE_TAX                        } from '../../modules/local/find_max_available_tax'
 include { QIIME_BARPLOT                                 } from '../../modules/nf-core/qiime/barplot/main'
 include { KRONA_REPORT                                  } from '../../subworkflows/local/krona_report'
 include { GROUP_COMPOSITION                             } from '../../modules/local/group_composition'
@@ -41,7 +42,17 @@ workflow DIVERSITY {
     
     QIIME2_PREPTAX( qiime_taxonomy.collect() )
 
-    QIIME_BARPLOT( QIIME2_FILTERSAMPLES.out.filtered_counts_qza, QIIME2_PREPTAX.out.taxonomy_qza, groups, tax_agglom_max )
+    FIND_MAX_AVAILABLE_TAX ( QIIME2_PREPTAX.out.taxonomy_tsv )
+    FIND_MAX_AVAILABLE_TAX.out.max_tax.subscribe { it ->
+        if (it.toInteger() < tax_agglom_max) { log.warn "Max available taxonomy is $it, but requested tax_agglom_max=$tax_agglom_max, switching to $it" }
+        if (it.toInteger() < tax_agglom_min) { log.warn "Max available taxonomy is $it, but requested tax_agglom_min=$tax_agglom_min, switching to $it" }
+    }
+
+    tax_min = FIND_MAX_AVAILABLE_TAX.out.max_tax.toInteger().map{ [it, tax_agglom_min].min() }
+    tax_max = FIND_MAX_AVAILABLE_TAX.out.max_tax.toInteger().map{ [it, tax_agglom_max].min() }
+
+
+    QIIME_BARPLOT( QIIME2_FILTERSAMPLES.out.filtered_counts_qza, QIIME2_PREPTAX.out.taxonomy_qza, groups, tax_max )
     ch_versions = ch_versions.mix( QIIME_BARPLOT.out.versions )
     ch_multiqc_files = ch_multiqc_files.mix( QIIME_BARPLOT.out.barplot_composition.collect() )
     ch_output_file_paths = ch_output_file_paths.mix(
@@ -54,7 +65,7 @@ workflow DIVERSITY {
         ch_output_file_paths = ch_output_file_paths.mix(KRONA_REPORT.out.html.map{ "${params.outdir}/krona/" + it.getName() } )
     }
 
-    QIIME2_EXPORT( QIIME2_FILTERSAMPLES.out.filtered_counts_qza, QIIME2_PREPTAX.out.taxonomy_qza, QIIME2_PREPTAX.out.taxonomy_tsv, tax_agglom_min, tax_agglom_max )
+    QIIME2_EXPORT( QIIME2_FILTERSAMPLES.out.filtered_counts_qza, QIIME2_PREPTAX.out.taxonomy_qza, QIIME2_PREPTAX.out.taxonomy_tsv, tax_min, tax_max )
     ch_output_file_paths = ch_output_file_paths.mix(
         QIIME2_EXPORT.out.abs_taxa_levels.flatten().map{ "${params.outdir}/qiime2/export/" + it.getName() }
         )
@@ -76,7 +87,7 @@ workflow DIVERSITY {
     HEATMAP_INPUT( QIIME_BARPLOT.out.barplot_composition.collect(), QIIME2_DIVERSITY.out.filtered_metadata, params.top_taxa )
     ch_multiqc_files = ch_multiqc_files.mix( HEATMAP_INPUT.out.taxo_heatmap.collect())
     
-    QIIME2_ANCOMBC( QIIME2_DIVERSITY.out.filtered_metadata, QIIME2_EXPORT.out.collapse_qza, QIIME2_PREPTAX.out.taxonomy_qza, tax_agglom_min, tax_agglom_max, ancombc_fdr_cutoff )
+    QIIME2_ANCOMBC( QIIME2_DIVERSITY.out.filtered_metadata, QIIME2_EXPORT.out.collapse_qza, QIIME2_PREPTAX.out.taxonomy_qza, tax_min, tax_max, ancombc_fdr_cutoff )
     ch_output_file_paths = ch_output_file_paths.mix(
         QIIME2_ANCOMBC.out.ch_output_files.flatten().map{ "${params.outdir}/qiime2/ancombc/visualizations/qzv/" + it.getName() }
         )

--- a/subworkflows/local/qiime2_ancombc.nf
+++ b/subworkflows/local/qiime2_ancombc.nf
@@ -21,13 +21,16 @@ workflow QIIME2_ANCOMBC {
         .set{ ch_for_ancom_tax }
     QIIME2_ANCOMBC_INITIAL ( ch_for_ancom_tax )
 
-    QIIME2_ANCOMBC_INITIAL.out.failcheck.subscribe{ failfilter, taxlevel -> 
-        if (failfilter == "true") {
+    QIIME2_ANCOMBC_INITIAL.out.failcheck.subscribe{ failfilter, taxlevel ->
+        if (taxlevel == "1") {
+            log.info( "Skipping taxlevel 1 for ANCOM-BC" )
+        } 
+        else if (failfilter == "true") {
             log.warn( "WARNING: Summing your data at taxonomic level $taxlevel produced less than three rows (taxa), ANCOM can't proceed.")
         }        
     }
 
-    QIIME2_ANCOMBC_FILTER ( ch_metadata.combine( QIIME2_ANCOMBC_INITIAL.out.ancom ), tax_agglom_max, fdr_cutoff )
+    QIIME2_ANCOMBC_FILTER ( ch_metadata.combine( QIIME2_ANCOMBC_INITIAL.out.ancom ), tax_agglom_max.collect(), fdr_cutoff )
     QIIME2_ANCOMBC_PARSE(QIIME2_ANCOMBC_FILTER.out.to_mqc, QIIME2_ANCOMBC_FILTER.out.ref_group )
 
     emit:

--- a/subworkflows/local/qiime2_export.nf
+++ b/subworkflows/local/qiime2_export.nf
@@ -9,20 +9,10 @@ workflow QIIME2_EXPORT {
     ch_asv
     taxonomy_qza
     taxonomy_tsv
-    tax_agglom_min
-    tax_agglom_max
+    tax_min
+    tax_max
 
     main:
-    //Find max available taxonomy level, check against specified tax levels
-    FIND_MAX_AVAILABLE_TAX ( taxonomy_tsv )
-    FIND_MAX_AVAILABLE_TAX.out.max_tax.subscribe { it ->
-        if (it.toInteger() < tax_agglom_max) { log.warn "Max available taxonomy is $it, but requested tax_agglom_max=$tax_agglom_max, switching to $it" }
-        if (it.toInteger() < tax_agglom_min) { log.warn "Max available taxonomy is $it, but requested tax_agglom_min=$tax_agglom_min, switching to $it" }
-    }
-
-    tax_min = FIND_MAX_AVAILABLE_TAX.out.max_tax.toInteger().map{ [it, tax_agglom_min].min() }
-    tax_max = FIND_MAX_AVAILABLE_TAX.out.max_tax.toInteger().map{ [it, tax_agglom_max].min() }
-
     //export_filtered_dada_output (optional)
     QIIME2_EXPORT_ABSOLUTE ( ch_asv, taxonomy_qza, taxonomy_tsv, tax_min, tax_max )
 


### PR DESCRIPTION
If there is not enough sample information to produce qiime barplot information for taxonomic levels 1-7, qiime_export_absolute will error as it expects all files to be produced from this process.

This PR involves the following changes:

- Remove this expectation from qiime_export_absolute
- The check for maximum available taxa from the data vs maximum taxa as a parameter setting is now done earlier in the pipeline before qiime_barplot and sets taxa level limits for all downstream applicable qiime operations.
- ANCOM BC now announces that it is skipping taxonomic level 1.
